### PR TITLE
feat(app): bootstrap Nest + /healthz and /metrics with Prometheus

### DIFF
--- a/labs/001-cqrs-es/app/README.md
+++ b/labs/001-cqrs-es/app/README.md
@@ -1,0 +1,5 @@
+This folder is for the minimal application / mock service.
+Goals:
+- Accept command requests (create order)
+- Append events to a local file-based store (stub) for demo
+- Build a small projection (e.g., JSON file or SQLite) for reads

--- a/labs/001-cqrs-es/app/node/dist/app.module.d.ts
+++ b/labs/001-cqrs-es/app/node/dist/app.module.d.ts
@@ -1,0 +1,3 @@
+import 'reflect-metadata';
+export declare class AppModule {
+}

--- a/labs/001-cqrs-es/app/node/dist/app.module.js
+++ b/labs/001-cqrs-es/app/node/dist/app.module.js
@@ -1,0 +1,22 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AppModule = void 0;
+require("reflect-metadata");
+const common_1 = require("@nestjs/common");
+const health_controller_1 = require("./health/health.controller");
+const metrics_controller_1 = require("./infrastructure/metrics/metrics.controller");
+let AppModule = class AppModule {
+};
+exports.AppModule = AppModule;
+exports.AppModule = AppModule = __decorate([
+    (0, common_1.Module)({
+        controllers: [health_controller_1.HealthController, metrics_controller_1.MetricsController],
+        providers: [],
+    })
+], AppModule);

--- a/labs/001-cqrs-es/app/node/dist/health/health.controller.d.ts
+++ b/labs/001-cqrs-es/app/node/dist/health/health.controller.d.ts
@@ -1,0 +1,7 @@
+export declare class HealthController {
+    healthz(): {
+        ok: boolean;
+        service: string;
+        ts: string;
+    };
+}

--- a/labs/001-cqrs-es/app/node/dist/health/health.controller.js
+++ b/labs/001-cqrs-es/app/node/dist/health/health.controller.js
@@ -1,0 +1,28 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.HealthController = void 0;
+const common_1 = require("@nestjs/common");
+let HealthController = class HealthController {
+    healthz() {
+        return { ok: true, service: 'lab001', ts: new Date().toISOString() };
+    }
+};
+exports.HealthController = HealthController;
+__decorate([
+    (0, common_1.Get)('/healthz'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], HealthController.prototype, "healthz", null);
+exports.HealthController = HealthController = __decorate([
+    (0, common_1.Controller)()
+], HealthController);

--- a/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.controller.d.ts
+++ b/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.controller.d.ts
@@ -1,0 +1,3 @@
+export declare class MetricsController {
+    metrics(): Promise<string>;
+}

--- a/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.controller.js
+++ b/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.controller.js
@@ -1,0 +1,31 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MetricsController = void 0;
+const common_1 = require("@nestjs/common");
+const metrics_middleware_1 = require("./metrics.middleware");
+let MetricsController = class MetricsController {
+    async metrics() {
+        const registry = (0, metrics_middleware_1.getRegistry)();
+        return await registry.metrics();
+    }
+};
+exports.MetricsController = MetricsController;
+__decorate([
+    (0, common_1.Get)('/metrics'),
+    (0, common_1.Header)('Content-Type', 'text/plain; version=0.0.4; charset=utf-8'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", Promise)
+], MetricsController.prototype, "metrics", null);
+exports.MetricsController = MetricsController = __decorate([
+    (0, common_1.Controller)()
+], MetricsController);

--- a/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.middleware.d.ts
+++ b/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.middleware.d.ts
@@ -1,0 +1,10 @@
+import type { NestMiddleware } from '@nestjs/common';
+import { Registry } from 'prom-client';
+import type { Request, Response, NextFunction } from 'express';
+export declare class MetricsMiddleware implements NestMiddleware {
+    private readonly registry;
+    private readonly httpHistogram;
+    constructor();
+    use(req: Request, res: Response, next: NextFunction): void;
+}
+export declare function getRegistry(): Registry;

--- a/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.middleware.js
+++ b/labs/001-cqrs-es/app/node/dist/infrastructure/metrics/metrics.middleware.js
@@ -1,0 +1,58 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MetricsMiddleware = void 0;
+exports.getRegistry = getRegistry;
+const common_1 = require("@nestjs/common");
+const prom_client_1 = require("prom-client");
+let MetricsMiddleware = class MetricsMiddleware {
+    registry;
+    httpHistogram;
+    constructor() {
+        this.registry = new prom_client_1.Registry();
+        // export default process metrics too
+        (0, prom_client_1.collectDefaultMetrics)({ register: this.registry });
+        this.httpHistogram = new prom_client_1.Histogram({
+            name: 'http_server_request_duration_seconds',
+            help: 'HTTP server request duration (seconds)',
+            labelNames: ['method', 'route', 'status'],
+            buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
+        });
+        this.registry.registerMetric(this.httpHistogram);
+        // Expose registry globally via (req as any) to avoid singletons
+        global.__metricsRegistry = this.registry;
+        global.__httpHistogram = this.httpHistogram;
+    }
+    use(req, res, next) {
+        const start = process.hrtime.bigint();
+        res.on('finish', () => {
+            const end = process.hrtime.bigint();
+            const duration = Number(end - start) / 1e9; // seconds
+            const method = req.method.toUpperCase();
+            // Nest sets route later; if not available, fallback to req.path
+            const route = req.route?.path || req.path || 'unknown';
+            const status = res.statusCode.toString();
+            this.httpHistogram
+                .labels({ method, route, status })
+                .observe(duration);
+        });
+        next();
+    }
+};
+exports.MetricsMiddleware = MetricsMiddleware;
+exports.MetricsMiddleware = MetricsMiddleware = __decorate([
+    (0, common_1.Injectable)(),
+    __metadata("design:paramtypes", [])
+], MetricsMiddleware);
+// Helpers for controllers
+function getRegistry() {
+    return global.__metricsRegistry;
+}

--- a/labs/001-cqrs-es/app/node/dist/main.d.ts
+++ b/labs/001-cqrs-es/app/node/dist/main.d.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata';

--- a/labs/001-cqrs-es/app/node/dist/main.js
+++ b/labs/001-cqrs-es/app/node/dist/main.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+require("reflect-metadata");
+const core_1 = require("@nestjs/core");
+const app_module_1 = require("./app.module");
+const common_1 = require("@nestjs/common");
+const metrics_middleware_1 = require("./infrastructure/metrics/metrics.middleware");
+async function bootstrap() {
+    const app = await core_1.NestFactory.create(app_module_1.AppModule, { abortOnError: true });
+    // Global validation (DTOs en fases siguientes)
+    app.useGlobalPipes(new common_1.ValidationPipe({
+        whitelist: true,
+        transform: true
+    }));
+    // HTTP Metrics for all paths
+    const metricsMiddleware = new metrics_middleware_1.MetricsMiddleware();
+    app.use(metricsMiddleware.use.bind(metricsMiddleware));
+    const PORT = Number(process.env.PORT || 8080);
+    await app.listen(PORT);
+    // eslint-disable-next-line no-console
+    console.log(`[lab001] up on http://localhost:${PORT}  (/healthz, /metrics)`);
+}
+bootstrap();

--- a/labs/001-cqrs-es/app/node/package.json
+++ b/labs/001-cqrs-es/app/node/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lab001-cqrs-es-node",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lab 001 — CQRS + ES (Node/NestJS) bootstrap with /healthz and /metrics",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.0",
+    "@nestjs/core": "^10.4.0",
+    "@nestjs/platform-express": "^10.4.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "prom-client": "^15.1.2",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/labs/001-cqrs-es/app/node/src/app.module.ts
+++ b/labs/001-cqrs-es/app/node/src/app.module.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+import { Module } from '@nestjs/common';
+import { HealthController } from './health/health.controller';
+import { MetricsController } from './infrastructure/metrics/metrics.controller';
+
+@Module({
+  controllers: [HealthController, MetricsController],
+  providers: [],
+})
+export class AppModule {}

--- a/labs/001-cqrs-es/app/node/src/health/health.controller.ts
+++ b/labs/001-cqrs-es/app/node/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class HealthController {
+  @Get('/healthz')
+  healthz() {
+    return { ok: true, service: 'lab001', ts: new Date().toISOString() };
+  }
+}

--- a/labs/001-cqrs-es/app/node/src/infrastructure/metrics/metrics.controller.ts
+++ b/labs/001-cqrs-es/app/node/src/infrastructure/metrics/metrics.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { getRegistry } from './metrics.middleware';
+
+@Controller()
+export class MetricsController {
+  @Get('/metrics')
+  @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  async metrics(): Promise<string> {
+    const registry = getRegistry();
+    return await registry.metrics();
+  }
+}

--- a/labs/001-cqrs-es/app/node/src/infrastructure/metrics/metrics.middleware.ts
+++ b/labs/001-cqrs-es/app/node/src/infrastructure/metrics/metrics.middleware.ts
@@ -1,0 +1,52 @@
+import type { NestMiddleware } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import type { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class MetricsMiddleware implements NestMiddleware {
+  private readonly registry: Registry;
+  private readonly httpHistogram: Histogram<string>;
+
+  constructor() {
+    this.registry = new Registry();
+    // export default process metrics too
+    collectDefaultMetrics({ register: this.registry });
+
+    this.httpHistogram = new Histogram({
+      name: 'http_server_request_duration_seconds',
+      help: 'HTTP server request duration (seconds)',
+      labelNames: ['method', 'route', 'status'] as const,
+      buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
+    });
+
+    this.registry.registerMetric(this.httpHistogram);
+    // Expose registry globally via (req as any) to avoid singletons
+    (global as any).__metricsRegistry = this.registry;
+    (global as any).__httpHistogram = this.httpHistogram;
+  }
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const start = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const end = process.hrtime.bigint();
+      const duration = Number(end - start) / 1e9; // seconds
+      const method = req.method.toUpperCase();
+      // Nest sets route later; if not available, fallback to req.path
+      const route = (req as any).route?.path || req.path || 'unknown';
+      const status = res.statusCode.toString();
+
+      (this.httpHistogram as Histogram<string>)
+        .labels({ method, route, status })
+        .observe(duration);
+    });
+
+    next();
+  }
+}
+
+// Helpers for controllers
+export function getRegistry(): Registry {
+  return (global as any).__metricsRegistry as Registry;
+}

--- a/labs/001-cqrs-es/app/node/src/main.ts
+++ b/labs/001-cqrs-es/app/node/src/main.ts
@@ -1,0 +1,28 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+import { MetricsMiddleware } from './infrastructure/metrics/metrics.middleware';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { abortOnError: true });
+
+  // Global validation
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true
+    })
+  );
+
+  // HTTP Metrics for all paths
+  const metricsMiddleware = new MetricsMiddleware();
+  app.use(metricsMiddleware.use.bind(metricsMiddleware));
+
+  const PORT = Number(process.env.PORT || 8080);
+  await app.listen(PORT);
+  // eslint-disable-next-line no-console
+  console.log(`[lab001] up on http://localhost:${PORT}  (/healthz, /metrics)`);
+}
+
+bootstrap();

--- a/labs/001-cqrs-es/app/node/tsconfig.build.json
+++ b/labs/001-cqrs-es/app/node/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": false
+  }
+}

--- a/labs/001-cqrs-es/app/node/tsconfig.json
+++ b/labs/001-cqrs-es/app/node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/labs/001-cqrs-es/tests/chaos/pod-kill.yaml
+++ b/labs/001-cqrs-es/tests/chaos/pod-kill.yaml
@@ -1,0 +1,13 @@
+# Example chaos manifest (Kubernetes): kill one pod of the projector
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: kill-projector
+spec:
+  action: pod-kill
+  mode: one
+  selector:
+    namespaces: ["default"]
+    labelSelectors:
+      app: order-projector
+  duration: "30s"

--- a/labs/001-cqrs-es/tests/k6/orders.js
+++ b/labs/001-cqrs-es/tests/k6/orders.js
@@ -1,0 +1,15 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '30s',
+};
+
+export default function () {
+  const payload = JSON.stringify({ items: [{ sku: 'ABC', qty: 1 }], payment: { amount: 10 } });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  const res = http.post('http://localhost:8080/orders', payload, params);
+  check(res, { 'status is 200/201': (r) => r.status === 200 || r.status === 201 });
+  sleep(1);
+}


### PR DESCRIPTION
* **Summary**:** Create NestJS service exposing /healthz and /metrics.

* **What’s Included**: base module, health controller, Prometheus registry and HTTP histogram middleware.

* **How to Test**: npm i && npm run dev, curl endpoints.

* **Notes**: sets the ground for CQRS/ES, projector lag metric will be added later.