### PR TITLE
feat(eventstore): file-based append-only event store (JSONL)

### DIFF
--- a/labs/001-cqrs-es/app/README.md
+++ b/labs/001-cqrs-es/app/README.md
@@ -1,5 +1,33 @@
-This folder is for the minimal application / mock service.
-Goals:
-- Accept command requests (create order)
-- Append events to a local file-based store (stub) for demo
-- Build a small projection (e.g., JSON file or SQLite) for reads
+# Lab 001 — App (NestJS)
+
+This folder contains the minimal mock service for the CQRS + ES lab.
+
+## How to test right now
+
+### 1. Run the API (health + metrics)
+```bash
+cd app/node
+npm install
+npm run dev
+```
+
+With the server running at `http://localhost:8080`:
+
+- Healthcheck JSON:
+  ```bash
+  curl -s http://localhost:8080/healthz | jq
+  ```
+- Prometheus metrics (plain text):
+  ```bash
+  curl -s http://localhost:8080/metrics | head -n 20
+  ```
+
+### 2. Exercise the Event Store
+Run the manual script that appends an event and then replays the JSONL file:
+
+```bash
+cd app/node
+npx ts-node scripts/manual-event-store.ts
+```
+
+The script ensures `data/events.jsonl` exists, writes a new event with an incremental `offset`, and prints all stored events.

--- a/labs/001-cqrs-es/app/node/data/.gitignore
+++ b/labs/001-cqrs-es/app/node/data/.gitignore
@@ -1,0 +1,2 @@
+# Event Store generated data
+*.jsonl

--- a/labs/001-cqrs-es/app/node/package.json
+++ b/labs/001-cqrs-es/app/node/package.json
@@ -19,6 +19,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@types/express": "^5.0.3",
     "@types/node": "^22.5.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.5.4"

--- a/labs/001-cqrs-es/app/node/scripts/manual-event-store.ts
+++ b/labs/001-cqrs-es/app/node/scripts/manual-event-store.ts
@@ -1,0 +1,27 @@
+// store as a scripts/manual-event-store.ts
+import { FileEventStore } from '../src/infrastructure/eventstore/file-event-store';
+import { generateId } from '../src/common/id';
+import { now } from '../src/common/clock';
+
+async function main() {
+  const store = new FileEventStore();
+
+  const written = await store.append({
+    type: 'order.created',
+    payload: { orderId: generateId(), amount: 42 },
+    metadata: {
+      eventId: generateId(),
+      aggregateId: 'order-123',
+      version: 1,
+      ts: now(),
+    },
+  });
+  console.log('append ->', written);
+
+  console.log('stream from 0:');
+  for await (const event of store.stream(0)) {
+    console.log(event);
+  }
+}
+
+main().catch(console.error);

--- a/labs/001-cqrs-es/app/node/src/common/clock.ts
+++ b/labs/001-cqrs-es/app/node/src/common/clock.ts
@@ -1,0 +1,1 @@
+export const now = (): string => new Date().toISOString();

--- a/labs/001-cqrs-es/app/node/src/common/id.ts
+++ b/labs/001-cqrs-es/app/node/src/common/id.ts
@@ -1,0 +1,3 @@
+import { randomUUID } from 'crypto';
+
+export const generateId = (): string => randomUUID();

--- a/labs/001-cqrs-es/app/node/src/domain/events.ts
+++ b/labs/001-cqrs-es/app/node/src/domain/events.ts
@@ -1,0 +1,19 @@
+export interface EventMetadata {
+  eventId: string;
+  aggregateId: string;
+  version: number;
+  ts: string;
+}
+
+export interface DomainEvent<
+  TType extends string = string,
+  TPayload extends Record<string, unknown> = Record<string, unknown>
+> {
+  type: TType;
+  payload: TPayload;
+  metadata: EventMetadata;
+}
+
+export interface StoredEvent extends DomainEvent {
+  offset: number;
+}

--- a/labs/001-cqrs-es/app/node/src/infrastructure/eventstore/file-event-store.ts
+++ b/labs/001-cqrs-es/app/node/src/infrastructure/eventstore/file-event-store.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from 'fs';
+import { createReadStream } from 'fs';
+import { dirname, join } from 'path';
+import { createInterface } from 'readline';
+import { DomainEvent, StoredEvent } from '../../domain/events';
+
+const DEFAULT_DATA_DIR = join(process.cwd(), 'data');
+const DEFAULT_EVENTS_FILE = join(DEFAULT_DATA_DIR, 'events.jsonl');
+
+export class FileEventStore {
+  private initialized = false;
+  private lastOffset = -1;
+
+  constructor(private readonly filePath: string = DEFAULT_EVENTS_FILE) {}
+
+  async append(event: DomainEvent): Promise<StoredEvent> {
+    await this.ensureInitialized();
+
+    const offset = this.lastOffset + 1;
+    const record: StoredEvent = {
+      ...event,
+      offset,
+    };
+
+    const line = `${JSON.stringify(record)}\n`;
+    await fs.appendFile(this.filePath, line, 'utf8');
+
+    this.lastOffset = offset;
+    return record;
+  }
+
+  async *stream(fromOffset = 0): AsyncGenerator<StoredEvent> {
+    await this.ensureFileReady();
+
+    const stream = createReadStream(this.filePath, { encoding: 'utf8' });
+    const reader = createInterface({ input: stream, crlfDelay: Infinity });
+
+    try {
+      for await (const line of reader) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        const record = JSON.parse(trimmed) as StoredEvent;
+        if (record.offset >= fromOffset) {
+          yield record;
+        }
+      }
+    } finally {
+      reader.close();
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    await this.ensureFileReady();
+    this.lastOffset = await this.readLastOffset();
+    this.initialized = true;
+  }
+
+  private async ensureFileReady(): Promise<void> {
+    const directory = dirname(this.filePath);
+    await fs.mkdir(directory, { recursive: true });
+
+    try {
+      await fs.access(this.filePath);
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        await fs.writeFile(this.filePath, '', 'utf8');
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async readLastOffset(): Promise<number> {
+    try {
+      const handle = await fs.open(this.filePath, 'r');
+      try {
+        const stream = handle.createReadStream({ encoding: 'utf8' });
+        const reader = createInterface({ input: stream, crlfDelay: Infinity });
+        let lastOffset = -1;
+
+        for await (const line of reader) {
+          const trimmed = line.trim();
+          if (!trimmed) {
+            continue;
+          }
+
+          const record = JSON.parse(trimmed) as StoredEvent;
+          lastOffset = record.offset;
+        }
+
+        reader.close();
+        return lastOffset;
+      } finally {
+        await handle.close();
+      }
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        return -1;
+      }
+      throw err;
+    }
+  }
+}

--- a/labs/001-cqrs-es/docs/adr/0001-cqrs-es.md
+++ b/labs/001-cqrs-es/docs/adr/0001-cqrs-es.md
@@ -34,3 +34,4 @@ Adopt **CQRS** (segregated write/read paths) and **Event Sourcing** (append-only
 - C4 (Context/Container)
 - RFC 0001 (Read Models)
 - ADR 0002 (Outbox), ADR 0003 (Projections Store)
+- Implementation: labs/001-cqrs-es/app/node/src/infrastructure/eventstore/file-event-store.ts

--- a/labs/001-cqrs-es/docs/risk-register.md
+++ b/labs/001-cqrs-es/docs/risk-register.md
@@ -1,4 +1,4 @@
 # Risk Register
 - Projector lag causes stale reads → Mitigation: show version/lag; compensate with status.
-- Event store growth → Mitigation: snapshots, compaction strategy.
+- JSONL event store growth → Mitigation: scheduled snapshots, file rotation/compaction strategy.
 - Outbox delivery failures → Mitigation: retry with backoff, DLQ.


### PR DESCRIPTION
## Summary
- add shared event metadata contracts plus clock/id helpers for later use across modules
- implement a file-backed append-only event store that writes JSONL records under `data/events.jsonl`
- provide a manual ts-node script to append/stream events and document current verification steps
- link ADR 0001 to the implementation and expand the risk register with JSONL growth mitigation

## Testing
- npm run build
- npx ts-node scripts/manual-event-store.ts
