### PR TITLE
feat(order): create order command with idempotency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+Chose a specific template:
+
+- [Feature](?expand=1&template=feature.md)
+- [Bugfix](?expand=1&template=bugfix.md)
+- [Docs](?expand=1&template=docs.md)
+- [Chore](?expand=1&template=chore.md)

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,50 @@
+---
+name: Bug Fix
+about: Template for pull requests that address reported bugs or regressions.
+---
+
+# Summary
+<!-- Provide a short description of the bug and the fix. -->
+
+# Root Cause
+<!-- Explain the underlying issue (what failed and why). -->
+
+# Repro Steps (Before)
+<!--
+1. Step 1
+2. Step 2
+3. Observed behavior: …
+-->
+
+# Fix Details (After)
+<!--
+- What changed in code/config
+- Why this resolves the issue
+- Any trade-offs
+-->
+
+# Affected Scope
+<!-- List components, services, or user journeys impacted. Note backward compatibility concerns. -->
+
+# How to Test / Verify
+<!--
+1. Steps to reproduce now show expected behavior
+2. Include tests or logs that demonstrate the fix
+-->
+
+# Risk & Rollback Plan
+<!--
+- Residual risks
+- Rollback steps
+- Feature flag / canary recommended?
+-->
+
+# Checklist
+- [ ] Regression/Unit tests added
+- [ ] Added/updated docs (if behavior changed)
+- [ ] Linked issue(s) closed (e.g., Fixes #123)
+- [ ] Labels set (bug, severity, area)
+- [ ] Backport required? If yes, list target branches
+
+# Post-Deployment Checks (optional)
+<!-- Note metrics/alerts to watch or user reports to monitor after deploy. -->

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,28 @@
+---
+name: Chore
+about: Template for maintenance work such as refactors, dependency bumps, CI tweaks, or formatting jobs.
+---
+
+# Summary
+<!-- Describe the maintenance/change (refactor, dependency bump, CI tweak, formatting update, etc.). -->
+
+# Motivation
+<!-- Explain why this is needed (tech debt, security advisory, CI speed, readability). -->
+
+# Scope
+<!-- List what is included and explicitly call out what’s out of scope. -->
+
+# Behavior Change
+<!-- Should be no-op for users? If not, describe impacts. -->
+
+# How to Test
+<!-- List commands, CI job links, quick checks, or areas to smoke-test for refactors. -->
+
+# Risk & Rollback Plan (optional)
+<!-- Note potential risks and how to revert if issues arise. Skip if no meaningful risk. -->
+
+# Checklist
+- [ ] CI green
+- [ ] No user-facing changes (or documented)
+- [ ] Labels set (chore/refactor/deps)
+- [ ] Security notices addressed (if deps)

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,33 @@
+---
+name: Documentation Update
+about: Template for pull requests that revise or add documentation.
+---
+
+# Summary
+<!-- Describe what documentation changed and why. -->
+
+# Audience & Scope
+<!-- Note who this is for (devs, ops, users) and which areas are covered. -->
+
+# Changes
+<!--
+- New pages/sections
+- Updated examples
+- Removed or deprecated content
+-->
+
+# Screenshots / Previews
+<!-- Add images or links to rendered docs if available. -->
+
+# Link Validation
+- [ ] Internal links verified
+- [ ] External links verified (or marked with TODO)
+
+# How to Review
+<!-- Note where to start and what to review (accuracy, completeness, tone). -->
+
+# Checklist
+- [ ] Examples compile/run (if applicable)
+- [ ] Versioning notes added (if needed)
+- [ ] Search/TOC updated
+- [ ] Labels set (docs, area)

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,44 @@
+---
+name: Feature
+about: Template for pull requests that add new features or significant enhancements.
+---
+
+# Summary
+<!-- Briefly describe the *what* and *why*. -->
+
+# Context & Links
+<!-- Add related issues/ADRs/RFCs (e.g., Closes #123) and supporting context like screenshots or diagrams. -->
+
+# Changes
+<!--
+- Item 1
+- Item 2
+- Item 3
+-->
+
+# Screenshots / Demos (if applicable)
+<!-- Add Before/After imagery, GIFs, or demo commands if helpful. -->
+
+# How to Test
+<!--
+1. Steps to set up the environment
+2. Commands to run
+3. What to expect
+-->
+
+# Risk & Rollback Plan
+<!--
+- Known risks or edge cases
+- Feature flag or config toggle?
+- Rollback steps if needed
+-->
+
+# Checklist
+- [ ] Unit/Integration tests added or updated
+- [ ] Docs updated (README/CHANGELOG)
+- [ ] No breaking changes (or clearly documented)
+- [ ] Labels set (feature/area)
+- [ ] Security/UX review (if applicable)
+
+# Release Notes (optional)
+<!-- Provide a short user-facing note for the changelog. -->

--- a/labs/001-cqrs-es/app/README.md
+++ b/labs/001-cqrs-es/app/README.md
@@ -31,3 +31,26 @@ npx ts-node scripts/manual-event-store.ts
 ```
 
 The script ensures `data/events.jsonl` exists, writes a new event with an incremental `offset`, and prints all stored events.
+
+### 3. Create an order via HTTP
+With the API running you can submit a `CreateOrder` command. The endpoint is idempotent by `client_request_id`:
+
+```bash
+curl -s http://localhost:8080/orders \
+  -H 'content-type: application/json' \
+  -d '{
+    "clientRequestId": "17b6e695-7cbd-4bd5-b62e-ff3f6ccab04c",
+    "customerId": "5e2ad359-8624-4bd9-8d8c-31f04b7ce986",
+    "currency": "USD",
+    "items": [
+      { "sku": "widget-001", "quantity": 2, "unitPrice": 25 }
+    ],
+    "payment": {
+      "method": "credit_card",
+      "amount": 50,
+      "currency": "USD"
+    }
+  }' | jq
+```
+
+Replaying the same request returns the same `orderId` without duplicating events.

--- a/labs/001-cqrs-es/app/node/src/app.module.ts
+++ b/labs/001-cqrs-es/app/node/src/app.module.ts
@@ -2,9 +2,12 @@ import 'reflect-metadata';
 import { Module } from '@nestjs/common';
 import { HealthController } from './health/health.controller';
 import { MetricsController } from './infrastructure/metrics/metrics.controller';
+import { OrdersController } from './infrastructure/http/orders.controller';
+import { FileEventStore } from './infrastructure/eventstore/file-event-store';
+import { CreateOrderHandler } from './application/handlers/create-order.handler';
 
 @Module({
-  controllers: [HealthController, MetricsController],
-  providers: [],
+  controllers: [HealthController, MetricsController, OrdersController],
+  providers: [FileEventStore, CreateOrderHandler],
 })
 export class AppModule {}

--- a/labs/001-cqrs-es/app/node/src/application/handlers/create-order.handler.ts
+++ b/labs/001-cqrs-es/app/node/src/application/handlers/create-order.handler.ts
@@ -1,0 +1,115 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { FileEventStore } from '../../infrastructure/eventstore/file-event-store';
+import { CreateOrderCommand } from '../../domain/commands/create-order';
+import {
+  OrderCreatedEvent,
+  OrderItem,
+  PaymentRequestedEvent
+} from '../../domain/aggregates/order';
+import { generateId } from '../../common/id';
+import { now } from '../../common/clock';
+import { StoredEvent } from '../../domain/events';
+
+export interface CreateOrderResult {
+  orderId: string;
+  created: boolean;
+}
+
+@Injectable()
+export class CreateOrderHandler {
+  constructor(private readonly eventStore: FileEventStore) {}
+
+  async execute(command: CreateOrderCommand): Promise<CreateOrderResult> {
+    const existing = await this.findByClientRequestId(command.clientRequestId);
+    if (existing) {
+      return { orderId: existing.payload.orderId, created: false };
+    }
+
+    const totalAmount = calculateTotalAmount(command);
+    validatePayment(command, totalAmount);
+
+    const orderId = generateId();
+    const items: OrderItem[] = command.items.map((item) => ({
+      sku: item.sku,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice
+    }));
+
+    const createdEvent: OrderCreatedEvent = {
+      type: 'order.created',
+      payload: {
+        orderId,
+        clientRequestId: command.clientRequestId,
+        customerId: command.customerId,
+        items,
+        totalAmount,
+        currency: command.currency
+      },
+      metadata: {
+        eventId: generateId(),
+        aggregateId: orderId,
+        version: 1,
+        ts: now()
+      }
+    };
+
+    await this.eventStore.append(createdEvent);
+
+    if (command.payment) {
+      const paymentEvent: PaymentRequestedEvent = {
+        type: 'payment.requested',
+        payload: {
+          orderId,
+          clientRequestId: command.clientRequestId,
+          amount: command.payment.amount,
+          currency: command.payment.currency,
+          method: command.payment.method
+        },
+        metadata: {
+          eventId: generateId(),
+          aggregateId: orderId,
+          version: 2,
+          ts: now()
+        }
+      };
+
+      await this.eventStore.append(paymentEvent);
+    }
+
+    return { orderId, created: true };
+  }
+
+  private async findByClientRequestId(
+    clientRequestId: string
+  ): Promise<(StoredEvent & OrderCreatedEvent) | null> {
+    for await (const event of this.eventStore.stream(0)) {
+      if (
+        event.type === 'order.created' &&
+        event.payload.clientRequestId === clientRequestId
+      ) {
+        return event as StoredEvent & OrderCreatedEvent;
+      }
+    }
+
+    return null;
+  }
+}
+
+const calculateTotalAmount = (command: CreateOrderCommand): number => {
+  return command.items.reduce((acc, item) => acc + item.quantity * item.unitPrice, 0);
+};
+
+const validatePayment = (command: CreateOrderCommand, totalAmount: number): void => {
+  if (!command.payment) {
+    return;
+  }
+
+  if (command.payment.currency !== command.currency) {
+    throw new BadRequestException('payment currency must match order currency');
+  }
+
+  const TOLERANCE = 1e-6;
+  if (Math.abs(command.payment.amount - totalAmount) > TOLERANCE) {
+    throw new BadRequestException('payment amount must match order total');
+  }
+};

--- a/labs/001-cqrs-es/app/node/src/domain/aggregates/order.ts
+++ b/labs/001-cqrs-es/app/node/src/domain/aggregates/order.ts
@@ -1,0 +1,79 @@
+import { DomainEvent } from '../events';
+
+export type OrderStatus = 'empty' | 'created' | 'payment-requested';
+
+export interface OrderItem extends Record<string, unknown> {
+  sku: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface OrderCreatedPayload extends Record<string, unknown> {
+  orderId: string;
+  clientRequestId: string;
+  customerId: string;
+  items: OrderItem[];
+  totalAmount: number;
+  currency: string;
+}
+
+export type OrderCreatedEvent = DomainEvent<'order.created', OrderCreatedPayload>;
+
+export interface PaymentRequestedPayload extends Record<string, unknown> {
+  orderId: string;
+  clientRequestId: string;
+  amount: number;
+  currency: string;
+  method: string;
+}
+
+export type PaymentRequestedEvent = DomainEvent<'payment.requested', PaymentRequestedPayload>;
+
+export type OrderEvent = OrderCreatedEvent | PaymentRequestedEvent;
+
+export interface OrderState {
+  status: OrderStatus;
+  orderId: string | null;
+  version: number;
+  clientRequestId: string | null;
+  totalAmount: number | null;
+  currency: string | null;
+  paymentRequested: boolean;
+}
+
+export const initialOrderState: OrderState = {
+  status: 'empty',
+  orderId: null,
+  version: 0,
+  clientRequestId: null,
+  totalAmount: null,
+  currency: null,
+  paymentRequested: false
+};
+
+export const applyOrderEvent = (state: OrderState, event: OrderEvent): OrderState => {
+  switch (event.type) {
+    case 'order.created':
+      return {
+        status: 'created',
+        orderId: event.payload.orderId,
+        version: event.metadata.version,
+        clientRequestId: event.payload.clientRequestId,
+        totalAmount: event.payload.totalAmount,
+        currency: event.payload.currency,
+        paymentRequested: false
+      };
+    case 'payment.requested':
+      return {
+        ...state,
+        status: 'payment-requested',
+        version: event.metadata.version,
+        paymentRequested: true
+      };
+    default:
+      return state;
+  }
+};
+
+export const reduceOrder = (events: OrderEvent[]): OrderState =>
+  events.reduce<OrderState>((state, event) => applyOrderEvent(state, event), initialOrderState);

--- a/labs/001-cqrs-es/app/node/src/domain/commands/create-order.ts
+++ b/labs/001-cqrs-es/app/node/src/domain/commands/create-order.ts
@@ -1,0 +1,65 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  Min,
+  ValidateNested
+} from 'class-validator';
+
+export class CreateOrderItemDto {
+  @IsString()
+  @IsNotEmpty()
+  sku!: string;
+
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+
+  @IsNumber()
+  @Min(0)
+  unitPrice!: number;
+}
+
+export class CreateOrderPaymentDto {
+  @IsString()
+  @IsNotEmpty()
+  method!: string;
+
+  @IsNumber()
+  @Min(0)
+  amount!: number;
+
+  @IsString()
+  @Matches(/^[A-Z]{3}$/)
+  currency!: string;
+}
+
+export class CreateOrderCommand {
+  @IsUUID()
+  clientRequestId!: string;
+
+  @IsUUID()
+  customerId!: string;
+
+  @IsString()
+  @Matches(/^[A-Z]{3}$/)
+  currency!: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateOrderItemDto)
+  items!: CreateOrderItemDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateOrderPaymentDto)
+  payment?: CreateOrderPaymentDto;
+}

--- a/labs/001-cqrs-es/app/node/src/infrastructure/eventstore/file-event-store.ts
+++ b/labs/001-cqrs-es/app/node/src/infrastructure/eventstore/file-event-store.ts
@@ -2,16 +2,21 @@ import { promises as fs } from 'fs';
 import { createReadStream } from 'fs';
 import { dirname, join } from 'path';
 import { createInterface } from 'readline';
+import { Injectable } from '@nestjs/common';
 import { DomainEvent, StoredEvent } from '../../domain/events';
 
 const DEFAULT_DATA_DIR = join(process.cwd(), 'data');
 const DEFAULT_EVENTS_FILE = join(DEFAULT_DATA_DIR, 'events.jsonl');
 
+@Injectable()
 export class FileEventStore {
   private initialized = false;
   private lastOffset = -1;
+  private readonly filePath: string;
 
-  constructor(private readonly filePath: string = DEFAULT_EVENTS_FILE) {}
+  constructor() {
+    this.filePath = DEFAULT_EVENTS_FILE;
+  }
 
   async append(event: DomainEvent): Promise<StoredEvent> {
     await this.ensureInitialized();

--- a/labs/001-cqrs-es/app/node/src/infrastructure/http/orders.controller.ts
+++ b/labs/001-cqrs-es/app/node/src/infrastructure/http/orders.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, HttpStatus, Post, Res } from '@nestjs/common';
+import { CreateOrderCommand } from '../../domain/commands/create-order';
+import { CreateOrderHandler } from '../../application/handlers/create-order.handler';
+import type { Response } from 'express';
+
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly createOrderHandler: CreateOrderHandler) {}
+
+  @Post()
+  async create(
+    @Body() command: CreateOrderCommand,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<{ orderId: string }> {
+    const result = await this.createOrderHandler.execute(command);
+    res.status(result.created ? HttpStatus.CREATED : HttpStatus.OK);
+    return { orderId: result.orderId };
+  }
+}

--- a/labs/001-cqrs-es/docs/adr/0002-outbox-pattern.md
+++ b/labs/001-cqrs-es/docs/adr/0002-outbox-pattern.md
@@ -1,6 +1,6 @@
 # ADR 0002: Use the Outbox Pattern for Integration Events
 
-- Status: Accepted
+- Status: Proposed
 - Date: 2025-09-18
 - Deciders: Architecture Labs
 - Tags: outbox, reliability, idempotency, integration-events

--- a/labs/001-cqrs-es/docs/sequence.mmd
+++ b/labs/001-cqrs-es/docs/sequence.mmd
@@ -7,10 +7,20 @@ sequenceDiagram
   participant P as Projector
   participant R as Read DB
 
-  C->>API: POST /orders { items, payment }
-  API->>H: validate+build Command
-  H->>ES: append(OrderCreated, PaymentRequested)
-  Note over H: Outbox: IntegrationEvent(PaymentRequested)
+  C->>API: POST /orders { items, client_request_id, payment? }
+  API->>H: validate & build CreateOrder command
+  H->>ES: stream(client_request_id)
+  alt duplicate request
+    H-->>API: reuse existing orderId
+  else new order
+    H->>ES: append(OrderCreated)
+    opt payment requested
+      H->>ES: append(PaymentRequested)
+      Note over H: Outbox dispatch (ADR-0002 Proposed)
+    end
+    H-->>API: new orderId
+  end
+  API-->>C: 200/201 { orderId }
 
   P-->>ES: subscribe(stream)
   ES-->>P: event(OrderCreated)


### PR DESCRIPTION
# Summary
Adds the CreateOrder command flow, including idempotent handling based on clientRequestId, and wires it into the Nest API so POST /orders persists OrderCreated (and optional PaymentRequested) events in the file-backed store.

# Context & Links
References ADR 0002 (Outbox Pattern) now marked as Proposed while the dispatcher remains pending. Sequence diagram docs/sequence.mmd updated to illustrate the new command path.

# Changes

- Introduced order aggregate reducer, command DTO validation, and application handler with event store integration.
- Exposed POST /orders controller returning 201/200 depending on idempotent replay.
- Updated docs (ADR status, sequence diagram, app README curl example).

# Screenshots / Demos (if applicable)
N/A

# How to Test

1. cd labs/001-cqrs-es/app/node && npm install
2. npm run dev
3. Send the sample POST from the README (Step 3) twice; observe the same orderId both times and a single pair of events in data/events.jsonl.

# Risk & Rollback Plan
Risk: malformed requests could poison the JSONL event log (no schema enforcement beyond DTO validation).
Rollback: revert commit and remove the appended events from data/events.jsonl if necessary.


# Checklist
- [ ] Unit/Integration tests added or updated
- [x] Docs updated (README/CHANGELOG)
- [x] No breaking changes (or clearly documented)
- [ ] Labels set (feature/area)
- [ ] Security/UX review (if applicable)

# Release Notes (optional)
Added POST /orders endpoint using append-only event store with idempotency on clientRequestId.
