### PR TITLE
feat(outbox): add rabbitmq dispatcher integration

### DIFF
--- a/labs/001-cqrs-es/README.md
+++ b/labs/001-cqrs-es/README.md
@@ -12,8 +12,21 @@ Scale reads without write contention, keep full audit/history, and enable time-t
 ## Scope (MVP)
 - Commands → events (append-only store)
 - Projections in SQLite (OrderView)
-- Idempotency + Outbox (simulado) 
+- Idempotency + Outbox (RabbitMQ dispatcher)
 - Observability: /metrics (Prometheus)
 
 ## Out of scope (v2+)
 - Real payment gateway, multi-tenant isolation, Postgres prod, Kafka, snapshots.
+
+## Outbox + RabbitMQ Dispatcher
+1. **Start RabbitMQ**: `docker compose -f infra/docker-compose.yml up -d`. It exposes AMQP on `5672` and the management UI on `15672` (`guest`/`guest`). Queue defaults to `orders.integration-events` (`RABBITMQ_OUTBOX_QUEUE` overrides).
+2. **Run the service + dispatcher**:
+   - `cp .env.example .env` (or ensure the env vars below exist)
+   - `npm install`
+   - `npm run dev`
+   - Relevant env vars: `RABBITMQ_URL`, `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS`, and the `OUTBOX_DISPATCHER_*` knobs (poll interval, backoff, max attempts, failure injectors).
+3. **Verify delivery**: create an order (see "Create an Order via HTTP"), confirm the row in `data/outbox.sqlite` is marked sent, and inspect the payload via the RabbitMQ UI (`Get Message(s)` on `orders.integration-events`).
+4. **Simulate failures** (set env vars, restart app):
+   - `OUTBOX_DISPATCHER_FAIL_ONCE=true` – first message fails once before retry success.
+   - `OUTBOX_DISPATCHER_FAIL_EVENT_TYPE=order.created` – all events of that type fail; exercises max-attempt handling.
+   - `OUTBOX_DISPATCHER_FAIL_UNTIL_ATTEMPTS=3` – dispatcher retries until attempt 3, then succeeds. Logs show backoff progression and outbox attempts tracking.

--- a/labs/001-cqrs-es/app/README.md
+++ b/labs/001-cqrs-es/app/README.md
@@ -1,7 +1,15 @@
 # Lab 001 — App (NestJS)
 
-The implementation that used to live in `labs/001-cqrs-es/app/node` now lives in a dedicated repository so this monorepo can stay focused on architecture exercises.
+The reference implementation for the CQRS Ordering Service lives in the dedicated repository below. Follow the instructions here to run it with the RabbitMQ-backed outbox dispatcher used throughout this lab.
 
 - CQRS Ordering Service repository: https://github.com/JeffSkynird/cqrs-ordering-service
 
-Clone that project to find the full NestJS CQRS + Event Sourcing service (SQLite projections, outbox dispatcher, Prometheus `/metrics`, k6 load tests, Docker setup, etc.).
+## Outbox + RabbitMQ Dispatcher
+1. **Start RabbitMQ**: `docker compose -f infra/docker-compose.yml up -d` (AMQP `:5672`, management UI `:15672`, default creds `guest`/`guest`). Queue name defaults to `orders.integration-events` and is overrideable via `RABBITMQ_OUTBOX_QUEUE`.
+2. **Prepare environment**: `cp .env.example .env` (or export the variables), run `npm install`, then `npm run dev` to start the API and dispatcher worker.
+3. **Env vars** (already in `.env.example`):
+   - `RABBITMQ_URL` (`amqp://guest:guest@localhost:5672` by default)
+   - `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS` (propagated to Docker Compose)
+   - `OUTBOX_DISPATCHER_*` (poll interval, exponential backoff, max attempts, failure injectors: `FAIL_ONCE`, `FAIL_EVENT_TYPE`, `FAIL_UNTIL_ATTEMPTS`)
+4. **Verify delivery**: create an order via the HTTP API, check `data/outbox.sqlite` for a row marked `sent`, and use the RabbitMQ UI (`orders.integration-events` → *Get Message(s)*) to inspect the payload.
+5. **Simulate failures**: toggle the `OUTBOX_DISPATCHER_FAIL_*` env vars to observe retries/backoff in logs; the dispatcher updates attempt counters and `next_retry_at` in the outbox table.

--- a/labs/001-cqrs-es/docs/adr/0002-outbox-pattern.md
+++ b/labs/001-cqrs-es/docs/adr/0002-outbox-pattern.md
@@ -1,6 +1,6 @@
 # ADR 0002: Use the Outbox Pattern for Integration Events
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2025-09-18
 - Deciders: Architecture Labs
 - Tags: outbox, reliability, idempotency, integration-events
@@ -10,8 +10,8 @@ When persisting domain events (e.g., `OrderCreated`), we must also publish **int
 
 ## Decision
 Implement the **Outbox Pattern**:
-- In the same transaction as domain event append, write an **outbox** record.
-- A background **dispatcher** pulls outbox entries, publishes to the broker (simulated in the lab), retries with backoff, and marks as sent idempotently.
+- In the same transaction as domain event append, write an **outbox** record to `data/outbox.sqlite`.
+- A background **dispatcher** polls the outbox, retries with exponential backoff, and publishes integration events to RabbitMQ (`orders.integration-events`, persistent delivery) before idempotently marking rows as sent.
 
 ## Alternatives
 - **Direct publish** post-commit: risks lost messages during crashes.
@@ -34,4 +34,4 @@ Implement the **Outbox Pattern**:
 ## Links
 - ADR 0001 (CQRS+ES)
 - RFC 0001 (Read Models)
-- Runbook (Outbox stuck)
+- Runbook — "Outbox stuck queue" mitigations


### PR DESCRIPTION
# Summary
Document updates so the lab, runbook, and ADR reflect the RabbitMQ-backed outbox dispatcher (SQLite outbox, persistent queue delivery, retry/backoff workflow).

# Context & Links
N/A

# Changes

- Marked ADR 0002 as accepted and documented the RabbitMQ dispatcher + SQLite outbox details.
- Expanded runbook diagnostics/mitigations with RabbitMQ checks, queue depth, and dispatcher replay steps.
- Added RabbitMQ startup, env var, verification, and failure-simulation guidance to lab and app READMEs.

# Screenshots / Demos (if applicable)
N/A

# How to Test

1. Preview the Markdown files (labs/001-cqrs-es/docs/adr/0002-outbox-pattern.md, labs/001-cqrs-es/sre/runbook.md, labs/001-cqrs-es/README.md, labs/001-cqrs-es/app/README.md).
2. Confirm instructions match the RabbitMQ-based dispatcher behavior.

# Risk & Rollback Plan

- Risk is low (documentation-only change).
- Rollback by reverting the modified Markdown files.

# Checklist
- [ ] Unit/Integration tests added or updated
- [x] Docs updated (README/CHANGELOG)
- [x] No breaking changes (or clearly documented)
- [ ] Labels set (feature/area)
- [ ] Security/UX review (if applicable)

# Release Notes (optional)
Aligned ADR, runbook, and README guidance with the RabbitMQ outbox dispatcher implementation (persistent queue delivery, retries, env setup).